### PR TITLE
wrong PID

### DIFF
--- a/misc/hubot.init.d.centos.sh
+++ b/misc/hubot.init.d.centos.sh
@@ -44,7 +44,7 @@ case "$1" in
               cd $BOT_PATH && $DAEMON $DAEMON_ARGS" - $USER  >> \
               ${LOGFILE} 2>&1 &
       sleep 2
-      PID=`pgrep -u hubot node`
+      PID=`pgrep -u $USER node`
       echo $PID > $PIDFILE
     else
       (cd $BOT_PATH; $DAEMON $DAEMON_ARGS  >> ${LOGFILE} 2>&1 & echo $! > $PIDFILE)

--- a/misc/hubot.init.d.centos.sh
+++ b/misc/hubot.init.d.centos.sh
@@ -42,7 +42,10 @@ case "$1" in
     if [ "$(whoami)" != "$USER" ]; then
       runuser -c "[ -r $BOT_PATH/hubot.conf ] && . $BOT_PATH/hubot.conf && \
               cd $BOT_PATH && $DAEMON $DAEMON_ARGS" - $USER  >> \
-              ${LOGFILE} 2>&1 & echo $! > $PIDFILE
+              ${LOGFILE} 2>&1 &
+      sleep 2
+      PID=`pgrep -u hubot node`
+      echo $PID > $PIDFILE
     else
       (cd $BOT_PATH; $DAEMON $DAEMON_ARGS  >> ${LOGFILE} 2>&1 & echo $! > $PIDFILE)
     fi


### PR DESCRIPTION
Not sure if this is an improvement, but just suggesting some kind of update here (I see another pull request for a similar workaround, but it doesn't seem to have been merged). Also some discussion in https://github.com/spajus/hubot-example/issues/4

I originally tried taking $! into a variable and then doing pgrep -P, but I actually see two levels of processes to get to the node process - the 'runuser -c', which then is the parent of a '-bash -c' process, which in turn is the node process.

The pgrep here could, in theory, get the wrong process if there are other 'node' processes owned by the user that hubot is running as, but it's still better than the other workarounds I've seen. The 2s 'sleep' seems to be necessary just in terms of making sure that the process has forked. Could still use some more testing / refinement, possibly.